### PR TITLE
react-cropper: support ref prop created with useRef hook

### DIFF
--- a/types/react-cropper/index.d.ts
+++ b/types/react-cropper/index.d.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export interface ReactCropperProps extends Cropper.Options, Omit<React.HTMLProps<HTMLImageElement>, 'data' | 'ref'> {
-    ref?: string | ((cropper: null | ReactCropper) => any);
+    ref?: string | React.RefObject<Cropper | undefined> | ((cropper: null | ReactCropper) => any);
 }
 
 interface ReactCropper extends Cropper {} // tslint:disable-line no-empty-interface


### PR DESCRIPTION
allows to also pass refs created with the `useRef` hook. see https://github.com/roadmanfong/react-cropper/issues/134#issuecomment-593984770

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
